### PR TITLE
Update SoBooks website URL to sobooks.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ by your running environment.
 |--------------------------------------------------|----------------------------------------|-----------------|----------------------------------------|-----------------------------------|----------------------------------|
 | [智慧教育平台](#download-textbooks-for-kids)           | <https://basic.smartedu.cn/tchMaterial>   | ✅               | ❌                                      | ❌                                 | ❌                                |
 | [Talebook](#download-books-from-talebook)        | <https://github.com/talebook/talebook> | ✅               | ❌                                      | ❌                                 | ❌                                |
-| [SoBooks](#download-books-from-sobooks)          | <https://sobooks.net>                  | ✅               | ❌                                      | ✅                                 | ❌                                |
+| [SoBooks](#download-books-from-sobooks)          | <https://sobooks.cc>                  | ✅               | ❌                                      | ✅                                 | ❌                                |
 | [Telegram](#download-books-from-telegram-groups) | <https://t.me>                         | ✅               | ❌                                      | ❌                                 | ❌                                |
 | [Hsu Life](#download-books-from-hsu-life)        | <https://book.hsu.life>                | ✅               | ❌                                      | ❌                                 | ❌                                |
 

--- a/cmd/flags/config.go
+++ b/cmd/flags/config.go
@@ -51,7 +51,7 @@ var (
 
 	// SoBooks configurations.
 
-	SoBooksCode = "844283"
+	SoBooksCode = "244152"
 )
 
 func NewClientConfig() (*client.Config, error) {

--- a/cmd/sobooks.go
+++ b/cmd/sobooks.go
@@ -11,13 +11,13 @@ import (
 
 const (
 	lowestSobooksBookID = 18000
-	sobooksWebsite      = "https://sobooks.net"
+	sobooksWebsite      = "https://sobooks.cc"
 )
 
-// sobooksCmd used for download books from sobooks.net
+// sobooksCmd used for download books from sobooks.cc
 var sobooksCmd = &cobra.Command{
 	Use:   "sobooks",
-	Short: "A tool for downloading books from sobooks.net",
+	Short: "A tool for downloading books from sobooks.cc",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Set the default start index.
 		if flags.InitialBookID < lowestSobooksBookID {

--- a/internal/sobooks/metadata.go
+++ b/internal/sobooks/metadata.go
@@ -25,7 +25,7 @@ var (
 		driver.DIRECT:  "备份",
 	}
 	dateRe = regexp.MustCompile(`(?m)(\d{4})-(\d{2})-(\d{2})`)
-	linkRe = regexp.MustCompile(`(?m)https://sobooks\.net/go\.html\?url=(.*?)"(.*?[：:]\s?(\w+))?`)
+	linkRe = regexp.MustCompile(`(?m)https://sobooks\.cc/go\.html\?url=(.*?)"(.*?[：:]\s?(\w+))?`)
 )
 
 type BookLink struct {

--- a/internal/sobooks/metadata_test.go
+++ b/internal/sobooks/metadata_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestParseSobooksUrl(t *testing.T) {
-	client := resty.New().SetBaseURL("https://sobooks.net")
+	client := resty.New().SetBaseURL("https://sobooks.cc")
 
 	// unsupported 14320 11000
 	// 20081 16899 16240
@@ -18,9 +18,9 @@ func TestParseSobooksUrl(t *testing.T) {
 	resp, err := client.R().
 		SetCookie(&http.Cookie{
 			Name:   "mpcode",
-			Value:  "844283",
+			Value:  "244152",
 			Path:   "/",
-			Domain: "sobooks.net",
+			Domain: "sobooks.cc",
 		}).
 		SetPathParam("bookId", strconv.FormatInt(id, 10)).
 		SetHeader("referer", client.BaseURL).


### PR DESCRIPTION
## Changed
- Update the address of sobooks website, old address `sobook.net` has been discontinued.
- Update sobooks mpcode